### PR TITLE
Add coreapi example

### DIFF
--- a/server/app/coreapi_docs/tasks.py
+++ b/server/app/coreapi_docs/tasks.py
@@ -1,0 +1,28 @@
+from coreapi import Document, Link, Field
+
+from ..service import task as task_service
+
+
+def tasks_document():
+    """ Return the top level Document object, containing all the task instances. """
+    return Document(
+        url='/api/tasks/',
+        title='Tasks',
+        content={
+            'tasks': [task_document(task.id) for task in task_service.retrieve_tasks()],
+            'create_task': Link(action='post', fields=[
+                Field(name='title', required=True)
+            ])
+        }
+    )
+
+
+def task_document(identifier):
+    """ Return a Document object for a single task instance. """
+    task = task_service.retrieve_task(identifier)
+    return Document(
+        url=f'/api/tasks/{task.id}',
+        title='Task',
+        content=task.serialize
+    )
+

--- a/server/requirements/dev.txt
+++ b/server/requirements/dev.txt
@@ -1,5 +1,6 @@
 flake8
 coverage
+coreapi-cli
 click
 wsgicli
 wsgi_static_middleware

--- a/server/requirements/general.txt
+++ b/server/requirements/general.txt
@@ -4,3 +4,6 @@ requests
 redis
 SQLAlchemy
 psycopg2
+coreapi
+jsonhyperschema-codec
+openapi-codec


### PR DESCRIPTION
- [x] JSON Response.
    - Maybe I should use `JSONCodec`, but it has no `encode` method.
- [x] OpenAPI/Swagger Response.
    - https://github.com/core-api/python-openapi-codec
- [ ] JSONHyperSchema Response
    - `JSONHyperSchemaCodec` has also no `encode` method.
    - https://github.com/core-api/python-jsonhyperschema-codec/blob/master/jsonhyperschema_codec/__init__.py


| `application/json` | `application/openapi+json` |
|---|---|
| <img width="1001" alt="2016-12-30 4 52 35" src="https://cloud.githubusercontent.com/assets/5564044/21553528/28223870-ce4c-11e6-8203-a3071605609f.png"> | <img width="1005" alt="2016-12-30 4 49 57" src="https://cloud.githubusercontent.com/assets/5564044/21553530/2a75acc4-ce4c-11e6-895d-81d7c3845603.png"> |